### PR TITLE
Handle promise-based search params in home page

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -21,17 +21,18 @@ const resolveParam = (value: string | string[] | undefined) =>
 const isUae = (value: string | null | undefined) =>
   UAE_IDENTIFIERS.has(normalize(value));
 
-export default function Home({
-  searchParams = {},
+export default async function Home({
+  searchParams,
 }: {
-  searchParams?: PageSearchParams;
+  searchParams?: PageSearchParams | Promise<PageSearchParams>;
 }) {
+  const resolvedSearchParams = (await searchParams) ?? {};
   const headerList = headers();
   const headerCountry = GEO_HEADER_KEYS.map((key) => headerList.get(key)).find(Boolean);
   const showFromHeader = isUae(headerCountry);
 
-  const resolvedRegion = resolveParam(searchParams.region);
-  const resolvedCountry = resolveParam(searchParams.country);
+  const resolvedRegion = resolveParam(resolvedSearchParams.region);
+  const resolvedCountry = resolveParam(resolvedSearchParams.country);
   const showFromParams = isUae(resolvedRegion) || isUae(resolvedCountry);
 
   return <HomeClient showUaeOffer={showFromHeader || showFromParams} />;


### PR DESCRIPTION
## Summary
- update the home page server component to accept promise-based search params
- resolve search params before using them when determining whether to show the UAE offer

## Testing
- `npm run build` *(fails: unable to fetch the Nunito Sans font from Google Fonts in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d15edfa7b88332aadf4037e018ee3a