### PR TITLE
Fix Home page props typing for Next.js build

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -21,12 +21,12 @@ const resolveParam = (value: string | string[] | undefined) =>
 const isUae = (value: string | null | undefined) =>
   UAE_IDENTIFIERS.has(normalize(value));
 
-export default async function Home({
-  searchParams,
-}: {
-  searchParams?: PageSearchParams | Promise<PageSearchParams>;
-}) {
-  const resolvedSearchParams = (await searchParams) ?? {};
+type HomeProps = {
+  searchParams?: Promise<PageSearchParams>;
+};
+
+export default async function Home({ searchParams }: HomeProps) {
+  const resolvedSearchParams: PageSearchParams = (await searchParams) ?? {};
   const headerList = headers();
   const headerCountry = GEO_HEADER_KEYS.map((key) => headerList.get(key)).find(Boolean);
   const showFromHeader = isUae(headerCountry);


### PR DESCRIPTION
## Summary
- align the Home page searchParams typing with Next.js expectations so build-time validation passes

## Testing
- npm run build *(fails: unable to download Nunito Sans Google Font due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68d15fcae2488332962b246be4008d14