### PR TITLE
Fix header access with awaited headers call

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -27,7 +27,7 @@ type HomeProps = {
 
 export default async function Home({ searchParams }: HomeProps) {
   const resolvedSearchParams: PageSearchParams = (await searchParams) ?? {};
-  const headerList = headers();
+  const headerList = await headers();
   const headerCountry = GEO_HEADER_KEYS.map((key) => headerList.get(key)).find(Boolean);
   const showFromHeader = isUae(headerCountry);
 


### PR DESCRIPTION
## Summary
- await the Next.js headers helper before reading geo headers to match the new async return type

## Testing
- npm run build *(fails: unable to download Nunito Sans font in offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d1633a479083328b3b6fcb86605fdf