### PR TITLE
Add regional service list grid to home page

### DIFF
--- a/app/HomeClient.tsx
+++ b/app/HomeClient.tsx
@@ -8,6 +8,103 @@ import KeyAdvantages from "@/app/KeyAdvantages";
 import ComprehensiveModules from "@/app/ComprehensiveModules";
 import ChooseBluepms from "./ChooseBluepms";
 import AboutUsBoxes from "@/app/AboutUs";
+
+const REGIONAL_SERVICE_LIST = [
+    "Best POS for hotels in Abu Dhabi",
+    "Hotel management software in Riyadh - Riyadh",
+    "Best self-check-in kiosk solutions for Middle East Hotels",
+    "PMS software in Manipur - Imphal",
+    "Best channel manager in Asia Pacific",
+    "hotel software in Puducherry - Puducherry",
+    "Best revenue management tool in Africa",
+    "Best all-in-one PMS in Asia Pacific",
+    "PMS software in Chhattisgarh - Raipur",
+    "Best hotel booking engine in Middle East",
+    "hotel software in Jammu and Kashmir - Srinagar (summer), Jammu (winter)",
+    "Best payment solutions for Asia Pacific Hotels",
+    "Best all-in-one PMS in Africa",
+    "PMS software in Gujarat - Gandhinagar",
+    "Best channel manager in India",
+    "Hotel management software in Bengaluru - Bengaluru",
+    "Best payment solutions for India Hotels",
+    "hotel software in Uttarakhand - Dehradun",
+    "Best POS for hotels in Africa",
+    "PMS software in Dadra and Nagar Haveli and Daman and Diu - Daman",
+    "Best self-check-in kiosk solutions for Africa Hotels",
+    "Best revenue management tool in Middle East",
+    "Hotel management software in Delhi - New Delhi",
+    "hotel software in Kerala - Thiruvananthapuram",
+    "Best all-in-one PMS in India",
+    "PMS software in Ladakh - Leh",
+    "Best channel manager in Africa",
+    "Hotel management software in Mizoram - Aizawl",
+    "Best hotel booking engine in Asia Pacific",
+    "PMS software in Andhra Pradesh - Amaravati",
+    "Best POS for hotels in Middle East",
+    "hotel software in Chandigarh - Chandigarh",
+    "Best payment solutions for Africa Hotels",
+    "Hotel management software in Uttar Pradesh - Lucknow",
+    "Best revenue management tool in Asia Pacific",
+    "PMS software in Tripura - Agartala",
+    "Best self-check-in kiosk solutions for Asia Pacific Hotels",
+    "hotel software in Assam - Dispur",
+    "Best channel manager in Middle East",
+    "Hotel management software in Andaman and Nicobar Islands - Port Blair",
+    "PMS software in Bihar - Patna",
+    "Best hotel booking engine in Africa",
+    "hotel software in Himachal Pradesh - Shimla",
+    "Best all-in-one PMS in Middle East",
+    "PMS software in West Bengal - Kolkata",
+    "Best POS for hotels in Asia Pacific",
+    "Hotel management software in Punjab - Chandigarh",
+    "Best payment solutions for Middle East Hotels",
+    "PMS software in Meghalaya - Shillong",
+    "hotel software in Rajasthan - Jaipur",
+    "Best revenue management tool in India",
+    "Hotel management software in Tamil Nadu - Chennai",
+    "Best self-check-in kiosk solutions for India Hotels",
+    "PMS software in Jharkhand - Ranchi",
+    "Best channel manager for hotels in Dubai",
+    "hotel software in Telangana - Hyderabad",
+    "Best hotel booking engine in India",
+    "PMS software in Madhya Pradesh - Bhopal",
+    "Best all-in-one PMS for hotels in Doha",
+    "Hotel management software in Arunachal Pradesh - Itanagar",
+    "Best POS for hotels in Cairo",
+    "PMS software in Odisha - Bhubaneswar",
+    "Best revenue management tool for hotels in Istanbul",
+    "hotel software in Goa - Panaji",
+    "Best payment solutions for India Hotels in Mumbai",
+    "Hotel management software in Haryana - Chandigarh",
+    "Best self-check-in kiosk solutions for Middle East Hotels in Jeddah",
+    "PMS software in Sikkim - Gangtok",
+    "Best channel manager for hotels in Tehran",
+    "PMS software in Dubai - Dubai",
+    "Hotel management software in Abu Dhabi - Abu Dhabi",
+    "hotel software in Doha - Doha",
+    "Best channel manager in Sri Lanka",
+    "PMS software in Colombo - Colombo",
+    "Hotel management software in Maldives - Malé",
+    "hotel software in Kathmandu - Kathmandu",
+    "Best POS for hotels in Nepal",
+    "Best revenue management tool in Maldives",
+    "Hotel management software in Riyadh - Riyadh",
+    "PMS software in Jeddah - Jeddah",
+    "Best hotel booking engine in Sri Lanka",
+    "hotel software in Malé - Malé",
+    "Hotel management software in Muscat - Muscat",
+    "PMS software in Bahrain - Manama",
+    "Best payment solutions for Maldives Hotels",
+    "hotel software in Pokhara - Pokhara",
+    "Best all-in-one PMS in Nepal",
+    "Hotel management software in Kuwait City - Kuwait City",
+    "PMS software in Sharjah - Sharjah",
+    "Best channel manager in Maldives",
+    "hotel software in Colombo - Colombo",
+    "Best POS for hotels in Sri Lanka",
+    "Hotel management software in Kathmandu - Kathmandu",
+    "PMS software in Malé - Malé",
+];
 type HomeClientProps = {
     showUaeOffer?: boolean;
 };
@@ -140,6 +237,17 @@ export default function HomeClient({ showUaeOffer = false }: HomeClientProps) {
             {/* CHOOSE BLUEPMS PAGE */}
             <section className="snap-start snap-always min-h-[100dvh]" id="contact">
                 <ChooseBluepms />
+            </section>
+            <section className="snap-start snap-always w-full px-6 pb-16 pt-10">
+                <div className="mx-auto w-full max-w-6xl">
+                    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-5">
+                        {REGIONAL_SERVICE_LIST.map((item) => (
+                            <p key={item} className="text-sm font-medium text-white/10">
+                                {item}
+                            </p>
+                        ))}
+                    </div>
+                </div>
             </section>
         </div>
     );


### PR DESCRIPTION
## Summary
- add a regional service keyword grid at the bottom of the home page
- style the list with low-contrast text and a responsive five-column layout on large screens

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917259d65fc83328d753375fef469f3)