### PR TITLE
Fix GA4 import path for Next third-party script

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 /* app/layout.tsx */
 import "./globals.css";
 import { BackgroundGradientAnimation } from "@/components/ui/aurora-background";
+import { GoogleAnalytics } from "next/third-parties/google";
 import type { Metadata, Viewport } from "next";
 import { Nunito_Sans } from "next/font/google";
 export const metadata: Metadata = {
@@ -99,6 +100,7 @@ export default function RootLayout({
             {children}
           </div>
         </BackgroundGradientAnimation>
+        <GoogleAnalytics gaId="G-4CKVPB4HLY" />
       </body>
     </html>
   );


### PR DESCRIPTION
## Summary
- update Google Analytics import to use Next built-in third-party module path

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692d5b2b75c48332a779cc57aa47ca74)