### PR TITLE
Use inline GA4 script to remove missing module dependency

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,9 @@ import "./globals.css";
 import { BackgroundGradientAnimation } from "@/components/ui/aurora-background";
 import type { Metadata, Viewport } from "next";
 import { Nunito_Sans } from "next/font/google";
+import Script from "next/script";
+
+const GA_MEASUREMENT_ID = "G-4CKVPB4HLY";
 export const metadata: Metadata = {
   title: "BLUEPMS – AI-Powered Cloud Hotel Management Software",
   description:
@@ -99,6 +102,20 @@ export default function RootLayout({
             {children}
           </div>
         </BackgroundGradientAnimation>
+        <Script
+          src={`https://www.googletagmanager.com/gtag/js?id=${GA_MEASUREMENT_ID}`}
+          strategy="afterInteractive"
+        />
+        <Script id="ga4" strategy="afterInteractive">
+          {`
+            window.dataLayer = window.dataLayer || [];
+            function gtag(){dataLayer.push(arguments);}
+            gtag('js', new Date());
+            gtag('config', '${GA_MEASUREMENT_ID}', {
+              page_path: window.location.pathname,
+            });
+          `}
+        </Script>
       </body>
     </html>
   );


### PR DESCRIPTION
## Summary
- replace the GA4 tag with an inline `next/script` implementation to avoid the missing `@next/third-parties` module
- introduce a shared GA measurement ID constant for reuse in the layout

## Testing
- npm run build *(fails fetching Google Fonts because of network restrictions in the environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692d5b2b75c48332a779cc57aa47ca74)