### PR TITLE
Add client-side GA page view tracking

### DIFF
--- a/app/google-analytics.tsx
+++ b/app/google-analytics.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { useEffect } from "react";
+import { usePathname, useSearchParams } from "next/navigation";
+
+import { GA_MEASUREMENT_ID } from "@/lib/analytics";
+
+export function GoogleAnalytics() {
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  useEffect(() => {
+    if (!pathname) return;
+
+    const url = searchParams?.toString()
+      ? `${pathname}?${searchParams.toString()}`
+      : pathname;
+
+    window.gtag?.("config", GA_MEASUREMENT_ID, {
+      page_path: url,
+    });
+  }, [pathname, searchParams]);
+
+  return null;
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,7 +5,8 @@ import type { Metadata, Viewport } from "next";
 import { Nunito_Sans } from "next/font/google";
 import Script from "next/script";
 
-const GA_MEASUREMENT_ID = "G-4CKVPB4HLY";
+import { GA_MEASUREMENT_ID } from "@/lib/analytics";
+import { GoogleAnalytics } from "./google-analytics";
 export const metadata: Metadata = {
   title: "BLUEPMS – AI-Powered Cloud Hotel Management Software",
   description:
@@ -111,11 +112,9 @@ export default function RootLayout({
             window.dataLayer = window.dataLayer || [];
             function gtag(){dataLayer.push(arguments);}
             gtag('js', new Date());
-            gtag('config', '${GA_MEASUREMENT_ID}', {
-              page_path: window.location.pathname,
-            });
           `}
         </Script>
+        <GoogleAnalytics />
       </body>
     </html>
   );

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -1,0 +1,1 @@
+export const GA_MEASUREMENT_ID = "G-4CKVPB4HLY";


### PR DESCRIPTION
## Summary
- move GA measurement id to shared analytics helper
- add client-side GoogleAnalytics component to send page views on route changes
- adjust layout GA script initialization to rely on client-side page view tracking

## Testing
- npm run lint *(fails: Missing script: "lint")


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692d5fdcbe0883328795648cafbf631d)