### PR TITLE
Wrap Google Analytics tracker in Suspense

### DIFF
--- a/app/google-analytics.tsx
+++ b/app/google-analytics.tsx
@@ -14,18 +14,19 @@ declare global {
 export function GoogleAnalytics() {
   const pathname = usePathname();
   const searchParams = useSearchParams();
+  const searchParamsString = searchParams?.toString();
 
   useEffect(() => {
     if (!pathname) return;
 
-    const url = searchParams?.toString()
-      ? `${pathname}?${searchParams.toString()}`
+    const url = searchParamsString
+      ? `${pathname}?${searchParamsString}`
       : pathname;
 
     window.gtag?.("config", GA_MEASUREMENT_ID, {
       page_path: url,
     });
-  }, [pathname, searchParams]);
+  }, [pathname, searchParamsString]);
 
   return null;
 }

--- a/app/google-analytics.tsx
+++ b/app/google-analytics.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { useEffect } from "react";
+import { usePathname, useSearchParams } from "next/navigation";
+
+import { GA_MEASUREMENT_ID } from "@/lib/analytics";
+
+declare global {
+  interface Window {
+    gtag?: (...args: unknown[]) => void;
+  }
+}
+
+export function GoogleAnalytics() {
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  useEffect(() => {
+    if (!pathname) return;
+
+    const url = searchParams?.toString()
+      ? `${pathname}?${searchParams.toString()}`
+      : pathname;
+
+    window.gtag?.("config", GA_MEASUREMENT_ID, {
+      page_path: url,
+    });
+  }, [pathname, searchParams]);
+
+  return null;
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -111,7 +111,7 @@ export default function RootLayout({
         <Script id="ga4" strategy="afterInteractive">
           {`
             window.dataLayer = window.dataLayer || [];
-            function gtag(){dataLayer.push(arguments);} 
+            function gtag(){dataLayer.push(arguments);}
             gtag('js', new Date());
             gtag('config', '${GA_MEASUREMENT_ID}', {
               page_path: window.location.pathname,

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -113,6 +113,9 @@ export default function RootLayout({
             window.dataLayer = window.dataLayer || [];
             function gtag(){dataLayer.push(arguments);} 
             gtag('js', new Date());
+            gtag('config', '${GA_MEASUREMENT_ID}', {
+              page_path: window.location.pathname,
+            });
           `}
         </Script>
         <Suspense fallback={null}>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,8 +4,10 @@ import { BackgroundGradientAnimation } from "@/components/ui/aurora-background";
 import type { Metadata, Viewport } from "next";
 import { Nunito_Sans } from "next/font/google";
 import Script from "next/script";
+import { Suspense } from "react";
 
-const GA_MEASUREMENT_ID = "G-4CKVPB4HLY";
+import { GA_MEASUREMENT_ID } from "@/lib/analytics";
+import { GoogleAnalytics } from "./google-analytics";
 export const metadata: Metadata = {
   title: "BLUEPMS – AI-Powered Cloud Hotel Management Software",
   description:
@@ -109,13 +111,13 @@ export default function RootLayout({
         <Script id="ga4" strategy="afterInteractive">
           {`
             window.dataLayer = window.dataLayer || [];
-            function gtag(){dataLayer.push(arguments);}
+            function gtag(){dataLayer.push(arguments);} 
             gtag('js', new Date());
-            gtag('config', '${GA_MEASUREMENT_ID}', {
-              page_path: window.location.pathname,
-            });
           `}
         </Script>
+        <Suspense fallback={null}>
+          <GoogleAnalytics />
+        </Suspense>
       </body>
     </html>
   );

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -1,0 +1,1 @@
+export const GA_MEASUREMENT_ID = "G-4CKVPB4HLY";


### PR DESCRIPTION
## Summary
- wrap the GoogleAnalytics client component in a Suspense boundary to satisfy Next.js suspense requirements

## Testing
- npm run build *(fails: unable to fetch Nunito Sans from Google Fonts in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692d5fdcbe0883328795648cafbf631d)