### PR TITLE
Fix homepage scrolling on Chromium-based browsers

### DIFF
--- a/app/Home/HomeClient.tsx
+++ b/app/Home/HomeClient.tsx
@@ -177,7 +177,7 @@ export default function HomeClient() {
     };
     const goToContact = () => router.push("/contact");
     return (
-        <div className="min-h-[100dvh] w-full overflow-y-auto scroll-smooth snap-y snap-mandatory overscroll-y-contain">
+        <div className="h-[100dvh] w-full overflow-y-auto scroll-smooth snap-y snap-mandatory overscroll-y-contain">
             {/* HERO */}
             <section className="snap-start snap-always flex min-h-[100dvh] w-full flex-col items-center text-center px-6 py-16 sm:py-20 md:py-24 md:justify-center">
                 <div className="w-full max-w-5xl lg:max-w-[90vw] flex flex-col items-center gap-6 transform-gpu md:-translate-y-16 lg:-translate-y-20 mx-auto">


### PR DESCRIPTION
### Motivation
- Chrome and other Chromium-based browsers were not responding to trackpad or scrollbar input on the home page because the top-level scroll host expanded to content height instead of acting as a viewport-constrained scroller.
- Ensuring a fixed viewport-height container makes `overflow-y-auto` produce a real scrollable area so wheel/trackpad events affect the inner scroll position.

### Description
- Changed the main home scroll container class from `min-h-[100dvh]` to `h-[100dvh]` in `app/Home/HomeClient.tsx` so the root scroller has a fixed viewport height.
- Kept the existing `overflow-y-auto`, snap and layout classes unchanged so the snap/pagination behavior is preserved.

### Testing
- Ran the app in dev mode (`next dev`) and executed a Playwright check that simulated a wheel scroll and verified the inner scroller's `scrollTop` moved from `0` to `1006`, confirming scrolling works (succeeded).
- Captured a verification screenshot artifact after the Playwright run (available in CI artifacts).
- Attempted `npm run build`, which failed due to an external Google Fonts fetch error for `Nunito Sans` in this environment and is unrelated to the scroll change (build blocked).
- `npm run lint` could not be run because no `lint` script is defined in this repository (check skipped).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a13826fd4c8332a69e08175d21ccfd)