### PR TITLE
Make scrolling smooth and remove homepage snap behavior

### DIFF
--- a/app/Home/HomeClient.tsx
+++ b/app/Home/HomeClient.tsx
@@ -177,9 +177,9 @@ export default function HomeClient() {
     };
     const goToContact = () => router.push("/contact");
     return (
-        <div className="h-[100dvh] w-full overflow-y-auto scroll-smooth snap-y snap-mandatory overscroll-y-contain">
+        <div className="h-[100dvh] w-full overflow-y-auto scroll-smooth overscroll-y-contain">
             {/* HERO */}
-            <section className="snap-start snap-always flex min-h-[100dvh] w-full flex-col items-center text-center px-6 py-16 sm:py-20 md:py-24 md:justify-center">
+            <section className="flex min-h-[100dvh] w-full flex-col items-center text-center px-6 py-16 sm:py-20 md:py-24 md:justify-center">
                 <div className="w-full max-w-5xl lg:max-w-[90vw] flex flex-col items-center gap-6 transform-gpu md:-translate-y-16 lg:-translate-y-20 mx-auto">
                     <motion.h1
                         initial={{ opacity: 0, y: 24 }}
@@ -265,20 +265,20 @@ export default function HomeClient() {
                 </div>
             </section>
             {/* KEY ADVANTAGES PAGE */}
-            <section id="features" className="snap-start snap-always min-h-[100dvh]">
+            <section id="features" className="min-h-[100dvh]">
                 <KeyAdvantages />
             </section>
             {/* COMPREHENSIVE MODULES PAGE */}
-            <section className="snap-start snap-always min-h-[100dvh]">
+            <section className="min-h-[100dvh]">
                 <ComprehensiveModules />
             </section>
             {/* CHOOSE BLUEPMS PAGE */}
-            <section className="snap-start snap-always min-h-[100dvh]" id="contact">
+            <section className="min-h-[100dvh]" id="contact">
                 <ChooseBluepms />
             </section>
 
             {/* BROCHURE MODULES GRID (MOVED HERE) */}
-            <section id="modules" className="snap-start snap-always min-h-[100dvh] w-full flex flex-col items-center justify-center p-8">
+            <section id="modules" className="min-h-[100dvh] w-full flex flex-col items-center justify-center p-8">
                 <div className="flex flex-col items-center max-w-7xl mx-auto space-y-12">
                     <motion.h2
                         initial={{ opacity: 0, y: 30 }}
@@ -330,7 +330,7 @@ export default function HomeClient() {
                 </div>
             </section>
 
-            <section className="snap-start snap-always w-full">
+            <section className="w-full">
                 <Footer />
             </section>
         </div>

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,6 +1,17 @@
 /* globals.css (or app/globals.css) */
 @import "tailwindcss";
 
+html,
+body {
+  scroll-behavior: smooth;
+  -webkit-overflow-scrolling: touch;
+}
+
+/* Keep smooth scrolling on nested overflow containers as well. */
+* {
+  scroll-behavior: smooth;
+}
+
 
 
 /* --- Full-page plasma wrapper --- */


### PR DESCRIPTION
### Motivation
- Remove forced section snapping on the main page so users get a natural, continuous scroll experience across browsers and pages.
- Provide consistent smooth scrolling and mobile momentum behavior globally so nested overflow containers and iOS Safari behave smoothly.

### Description
- Removed Tailwind scroll-snap classes (`snap-y`, `snap-mandatory`, `snap-start`, `snap-always`, etc.) from the homepage container and all homepage sections in `app/Home/HomeClient.tsx` to disable forced snap behavior.
- Added global smooth scrolling by updating `app/globals.css` to set `scroll-behavior: smooth` on `html`, `body`, and all elements, and added `-webkit-overflow-scrolling: touch` to improve momentum scrolling on iOS.
- Left existing programmatic `scrollIntoView({ behavior: "smooth" })` usage intact so in-page navigation remains smooth.

### Testing
- Ran `rg -n "snap-(x|y|both|none|mandatory|proximity|start|end|center|always)"` across the app and confirmed no matches, verifying snap classes were removed (succeeded).
- Started the dev server with `npm run dev` and confirmed the app loads locally (dev server started successfully); Next warned about Google Fonts but used fallbacks (succeeded).
- Captured an automated Playwright screenshot of the home page to visually validate scrolling layout after the change; the capture completed successfully and the artifact was produced (succeeded).
- Ran `npm run build` to validate production build which failed in this environment due to a blocked Google Fonts fetch for `Nunito Sans`, not due to the scroll changes (build failed for unrelated font fetch issue).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a13c46c7a483328e38538786df9646)